### PR TITLE
Hide SaveBar on unmount synchronously

### DIFF
--- a/.changeset/silent-savebar-unmount.md
+++ b/.changeset/silent-savebar-unmount.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app-bridge-react': patch
+---
+
+Hide the App Bridge SaveBar synchronously when the React wrapper unmounts.

--- a/packages/app-bridge-react/src/components/SaveBar.tsx
+++ b/packages/app-bridge-react/src/components/SaveBar.tsx
@@ -5,8 +5,12 @@ import {
   useState,
   forwardRef,
   type ForwardedRef,
+  useLayoutEffect,
 } from 'react';
 import type {UISaveBarAttributes} from '@shopify/app-bridge-types';
+
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 declare global {
   namespace JSX {
@@ -73,7 +77,7 @@ export const SaveBar = forwardRef(function InternalSaveBar(
     };
   }, [saveBar, onHide]);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!saveBar) return;
     return () => {
       saveBar.hide();


### PR DESCRIPTION
## Summary

- Hide the App Bridge React `SaveBar` during unmount with an isomorphic layout effect.
- Add a patch changeset for `@shopify/app-bridge-react`.

## Why

React passive effect cleanup can run after the `ui-save-bar` element has been detached. In that case, the App Bridge SaveBar can remain visible after the React wrapper unmounts, leaving navigation blocked and stale Save/Discard handlers visible. Running the unmount cleanup in a browser layout effect keeps the element available while calling `hide()`, while still using `useEffect` on the server to avoid SSR layout-effect warnings.

Fixes #532.

## Validation

- `mise exec node@24.13.1 -- pnpm install --frozen-lockfile`
- `mise exec node@24.13.1 -- pnpm format:check`
- `mise exec node@24.13.1 -- pnpm build`
- `mise exec node@24.13.1 -- pnpm lint`
- `mise exec node@24.13.1 -- pnpm type-check`
- `mise exec node@24.13.1 -- pnpm test`