### PR TITLE
Relax App Bridge button prop types

### DIFF
--- a/.changeset/relax-button-augmentation-types.md
+++ b/.changeset/relax-button-augmentation-types.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app-bridge-types': patch
+---
+
+Allow custom design-system `variant` and `tone` values on globally augmented React button props.

--- a/packages/app-bridge-types/package.json
+++ b/packages/app-bridge-types/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@shopify/typescript-configs": "catalog:",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "cjyes": "^0.3.1",
     "typescript": "catalog:"
   },

--- a/packages/app-bridge-types/scripts/build.mjs
+++ b/packages/app-bridge-types/scripts/build.mjs
@@ -14,7 +14,29 @@ if (!response.ok) {
   );
 }
 
-const types = await response.text();
+const types = relaxGlobalMenuItemProperties(await response.text());
 await writeFile(outFile, types);
 
 console.log(`Downloaded types to ${outFile}`);
+
+function relaxGlobalMenuItemProperties(types) {
+  const exactMenuItemTypes = `interface MenuItemProperties {
+\tvariant?: "primary" | "breadcrumb" | null | undefined;
+\ttone?: "critical" | "default";
+\tdisabled?: boolean;
+\tloading?: boolean | string;
+}`;
+
+  const relaxedMenuItemTypes = `interface MenuItemProperties {
+\tvariant?: "primary" | "breadcrumb" | (string & {}) | null | undefined;
+\ttone?: "critical" | "default" | (string & {});
+\tdisabled?: boolean;
+\tloading?: boolean | string;
+}`;
+
+  if (!types.includes(exactMenuItemTypes)) {
+    throw new Error('Unable to find MenuItemProperties in downloaded types');
+  }
+
+  return types.replace(exactMenuItemTypes, relaxedMenuItemTypes);
+}

--- a/packages/app-bridge-types/tests/types.test.ts
+++ b/packages/app-bridge-types/tests/types.test.ts
@@ -1,4 +1,5 @@
 import {describe, it} from 'node:test';
+import type {ButtonHTMLAttributes} from 'react';
 
 import {Collection, Product, ProductVariant} from '..';
 
@@ -15,5 +16,18 @@ describe('App Bridge types', () => {
 
     const variants = await shopify.resourcePicker({type: 'variant'});
     expect<ProductVariant>(variants![0]).toPass();
+  });
+
+  it('allows UI libraries to narrow their own button props', () => {
+    interface LibraryButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+      variant?: 'ghost' | 'link';
+      tone?: 'neutral';
+    }
+
+    expect<LibraryButtonProps>({
+      type: 'button',
+      variant: 'ghost',
+      tone: 'neutral',
+    }).toPass();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.28
       cjyes:
         specifier: ^0.3.1
         version: 0.3.1


### PR DESCRIPTION
## Summary

- Relax the generated `MenuItemProperties` type so App Bridge's global React button augmentation allows custom `variant` and `tone` string values.
- Add a type regression test that mirrors design-system button props like `variant="ghost"` and `tone="neutral"`.
- Add a patch changeset for `@shopify/app-bridge-types`.

## Why

`@shopify/app-bridge-types` globally augments React's button and anchor attributes for App Bridge title bar and save bar actions. Those augmentations currently narrow every React `<button>` `variant` to `"primary" | "breadcrumb"` and every `tone` to `"critical" | "default"`, which leaks into unrelated design-system buttons and breaks common values such as `ghost`, `link`, or `neutral`.

This keeps the App Bridge literals available for autocomplete while allowing other string values used by app-level UI libraries.

Fixes #390
Fixes #490
Related #496

## Validation

- `mise exec node@24.13.1 -- pnpm --filter @shopify/app-bridge-types build`
- `mise exec node@24.13.1 -- pnpm --filter @shopify/app-bridge-types type-check`
- `mise exec node@24.13.1 -- pnpm format:check`
- `mise exec node@24.13.1 -- pnpm build`
- `mise exec node@24.13.1 -- pnpm lint` (exits 0; existing warning in `packages/app-bridge-react/vite.config.ts`)
- `mise exec node@24.13.1 -- pnpm type-check`
- `mise exec node@24.13.1 -- pnpm test`
- `git diff --check`
