### PR TITLE
fix(release): configure npm auth so changeset publish works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
+          # Writes registry=https://registry.npmjs.org/ to ~/.npmrc so that
+          # `changeset publish` (npm publish) targets the public registry and,
+          # combined with the id-token permission below, authenticates via npm
+          # OIDC Trusted Publishing — no static NPM_TOKEN secret required.
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install
@@ -43,3 +48,8 @@ jobs:
           title: 'Version Packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Emit npm provenance attestations (requires the id-token permission).
+          NPM_CONFIG_PROVENANCE: true
+          # Empty token forces npm to authenticate via OIDC Trusted Publishing
+          # rather than expecting a static auth token in ~/.npmrc.
+          NPM_TOKEN: ''


### PR DESCRIPTION
## Problem

Merging the Version Packages PR (#568) was expected to publish `@shopify/app-bridge-types@0.7.1` (and `@shopify/app-bridge-react@4.2.11`) to npm, but **nothing was published** — npm still shows `0.7.0` as `latest`.

The merge **did** trigger the Release workflow ([run 27210047656](https://github.com/Shopify/shopify-app-bridge/actions/runs/27210047656)). It built fine, then **failed at the publish step**:

```
🦋 info Publishing "@shopify/app-bridge-types" at "0.7.1"
🦋 error an error occurred while publishing @shopify/app-bridge-types:
        ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org
🦋 error packages failed to publish:
🦋  @shopify/app-bridge-react@4.2.11
🦋  @shopify/app-bridge-types@0.7.1
```

## Root cause

The Release workflow has **no npm authentication wired up**:
- `actions/setup-node` was configured without `registry-url`, so no registry/auth was written to `~/.npmrc`.
- The publish step passed only `GITHUB_TOKEN` — no npm token and no OIDC registry config.

So `npm publish` (invoked by `changeset publish`) had no credentials → `ENEEDAUTH`.

This never surfaced before because every prior `Release [ok]` run in this monorepo only **created/updated the Version Packages PR** — they never actually published. All versions ≤ `0.7.0` were published (2026‑02‑04 and earlier) from the legacy repo, *before* this monorepo was initialized (2026‑04‑02). **This merge was the first real publish attempt from this repo**, which is exactly when the missing auth bit us.

## Fix

The job already declares `id-token: write # Required for OIDC authentication` and runs **Node 24 (npm 11)**, so the original intent was clearly OIDC Trusted Publishing — the `registry-url` that activates it was just never added. This PR wires it up:

- Add `registry-url: 'https://registry.npmjs.org'` to `setup-node` so npm targets the public registry.
- Set `NPM_CONFIG_PROVENANCE: true` (provenance attestations via the existing `id-token` permission) and `NPM_TOKEN: ''` to force OIDC authentication.

This matches the secret-free pattern used by e.g. [`Shopify/shopify-function-javascript`](https://github.com/Shopify/shopify-function-javascript/blob/main/.github/workflows/release.yml).

## ⚠️ Required npm-side setup

OIDC Trusted Publishing requires a **trusted publisher entry on npmjs.org** for each package (`@shopify/app-bridge-types`, `@shopify/app-bridge-react`), keyed to this repo + the `release.yml` workflow filename. A maintainer with npm admin must add that under each package's *Settings → Publishing access → Trusted Publisher* (GitHub Actions, repo `Shopify/shopify-app-bridge`, workflow `release.yml`).

**Token fallback:** if Trusted Publishing isn't desired, swap `NPM_TOKEN: ''` for `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` and add the `NPM_TOKEN` repo secret (the pattern used by polaris-react / buy-button-js). Happy to switch this PR to that approach if preferred.

## Recovering 0.7.1

The version bump already landed on `main` (`package.json` = `0.7.1`, changeset consumed), so no new changeset is needed. Once auth is in place, **re-run the failed Release run** — `changeset publish` will detect that `0.7.1` / `4.2.11` aren't on npm and publish them.
