### PR TITLE
fix(app-bridge-react): stabilize SaveBar and Modal ref callbacks

### DIFF
--- a/.changeset/stabilize-savebar-modal-refs.md
+++ b/.changeset/stabilize-savebar-modal-refs.md
@@ -1,0 +1,7 @@
+---
+'@shopify/app-bridge-react': patch
+---
+
+Stabilize SaveBar and Modal ref callbacks so React 18 does not detach/attach (and setState) on every render.
+
+Fixes #565

--- a/packages/app-bridge-react/src/components/Modal.tsx
+++ b/packages/app-bridge-react/src/components/Modal.tsx
@@ -6,6 +6,7 @@ import {
   forwardRef,
   type ForwardedRef,
   Children,
+  useCallback,
 } from 'react';
 import ReactDOM from 'react-dom';
 import type {UIModalAttributes} from '@shopify/app-bridge-types';
@@ -50,6 +51,20 @@ export const Modal = forwardRef(function InternalModal(
   forwardedRef: ForwardedRef<UIModalElement>,
 ) {
   const [modal, setModal] = useState<UIModalElement | null>();
+
+  const refCallback = useCallback(
+    (modal: UIModalElement | null) => {
+      setModal(modal);
+      if (forwardedRef) {
+        if (typeof forwardedRef === 'function') {
+          forwardedRef(modal);
+        } else {
+          forwardedRef.current = modal;
+        }
+      }
+    },
+    [forwardedRef],
+  );
 
   const {titleBar, saveBar, modalContent} = Children.toArray(children).reduce(
     (acc, node) => {
@@ -111,19 +126,7 @@ export const Modal = forwardRef(function InternalModal(
   }, [modal]);
 
   return (
-    <ui-modal
-      {...rest}
-      ref={(modal) => {
-        setModal(modal);
-        if (forwardedRef) {
-          if (typeof forwardedRef === 'function') {
-            forwardedRef(modal);
-          } else {
-            forwardedRef.current = modal;
-          }
-        }
-      }}
-    >
+    <ui-modal {...rest} ref={refCallback}>
       {titleBar}
       {saveBar}
       <div>{contentPortal}</div>

--- a/packages/app-bridge-react/src/components/SaveBar.tsx
+++ b/packages/app-bridge-react/src/components/SaveBar.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   forwardRef,
   type ForwardedRef,
+  useCallback,
 } from 'react';
 import type {UISaveBarAttributes} from '@shopify/app-bridge-types';
 
@@ -48,6 +49,20 @@ export const SaveBar = forwardRef(function InternalSaveBar(
 ) {
   const [saveBar, setSaveBar] = useState<UISaveBarElement | null>();
 
+  const refCallback = useCallback(
+    (saveBar: UISaveBarElement | null) => {
+      setSaveBar(saveBar);
+      if (forwardedRef) {
+        if (typeof forwardedRef === 'function') {
+          forwardedRef(saveBar);
+        } else {
+          forwardedRef.current = saveBar;
+        }
+      }
+    },
+    [forwardedRef],
+  );
+
   useEffect(() => {
     if (!saveBar) return;
     if (open) {
@@ -81,19 +96,7 @@ export const SaveBar = forwardRef(function InternalSaveBar(
   }, [saveBar]);
 
   return (
-    <ui-save-bar
-      {...rest}
-      ref={(saveBar) => {
-        setSaveBar(saveBar);
-        if (forwardedRef) {
-          if (typeof forwardedRef === 'function') {
-            forwardedRef(saveBar);
-          } else {
-            forwardedRef.current = saveBar;
-          }
-        }
-      }}
-    >
+    <ui-save-bar {...rest} ref={refCallback}>
       {children}
     </ui-save-bar>
   );


### PR DESCRIPTION
## Summary

Fixes #565

SaveBar and Modal were creating a new inline ref callback on every render.
React treats changing callback refs as detach/attach operations, causing the
ref callback to run repeatedly and trigger internal state updates.

## Changes

- Replaced inline ref callbacks with memoized `useCallback` refs
- Preserved existing forwardedRef behavior for:
  - callback refs
  - object refs
  - unmount cleanup

## Validation

- ✅ pnpm lint
- ✅ pnpm test
- ✅ TypeScript diagnostics clean

Only modified:
- packages/app-bridge-react/src/components/SaveBar.tsx
- packages/app-bridge-react/src/components/Modal.tsx