### PR TITLE
Fix React 19 JSX type compatibility

### DIFF
--- a/.changeset/large-lizards-take.md
+++ b/.changeset/large-lizards-take.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app-bridge-react': patch
+---
+
+Fix React 19 JSX type compatibility for App Bridge web components

--- a/packages/app-bridge-react/src/components/Modal.tsx
+++ b/packages/app-bridge-react/src/components/Modal.tsx
@@ -1,7 +1,6 @@
 import {
   type ReactNode,
   useEffect,
-  type LegacyRef,
   useState,
   forwardRef,
   type ForwardedRef,
@@ -11,11 +10,11 @@ import {
 import ReactDOM from 'react-dom';
 import type {UIModalAttributes} from '@shopify/app-bridge-types';
 
-declare global {
+declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'ui-modal': UIModalAttributes & {
-        ref?: LegacyRef<UIModalElement | null>;
+        ref?: import('react').LegacyRef<UIModalElement | null>;
       };
     }
   }

--- a/packages/app-bridge-react/src/components/NavMenu.tsx
+++ b/packages/app-bridge-react/src/components/NavMenu.tsx
@@ -1,11 +1,11 @@
-import type {LegacyRef, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {UINavMenuAttributes} from '@shopify/app-bridge-types';
 
-declare global {
+declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'ui-nav-menu': UINavMenuAttributes & {
-        ref?: LegacyRef<UINavMenuElement | null>;
+        ref?: import('react').LegacyRef<UINavMenuElement | null>;
       };
     }
   }

--- a/packages/app-bridge-react/src/components/SaveBar.tsx
+++ b/packages/app-bridge-react/src/components/SaveBar.tsx
@@ -1,7 +1,6 @@
 import {
   type ReactNode,
   useEffect,
-  type LegacyRef,
   useState,
   forwardRef,
   type ForwardedRef,
@@ -9,11 +8,11 @@ import {
 } from 'react';
 import type {UISaveBarAttributes} from '@shopify/app-bridge-types';
 
-declare global {
+declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'ui-save-bar': UISaveBarAttributes & {
-        ref?: LegacyRef<UISaveBarElement | null>;
+        ref?: import('react').LegacyRef<UISaveBarElement | null>;
       };
     }
   }

--- a/packages/app-bridge-react/src/components/TitleBar.tsx
+++ b/packages/app-bridge-react/src/components/TitleBar.tsx
@@ -1,11 +1,11 @@
-import type {LegacyRef, ReactNode} from 'react';
+import type {ReactNode} from 'react';
 import type {UITitleBarAttributes} from '@shopify/app-bridge-types';
 
-declare global {
+declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'ui-title-bar': UITitleBarAttributes & {
-        ref?: LegacyRef<UITitleBarElement | null>;
+        ref?: import('react').LegacyRef<UITitleBarElement | null>;
       };
     }
   }


### PR DESCRIPTION
## Summary

Fixes #505

This PR updates the JSX type declarations in `@shopify/app-bridge-react` to support React 19 while preserving compatibility with existing React 18 applications.

## Problem

The App Bridge React components currently augment JSX intrinsic elements through the global `JSX` namespace:

```ts
declare global {
  namespace JSX {
    interface IntrinsicElements {
      'ui-modal': ...
    }
  }
}
```

With React 19, the JSX namespace is scoped to the react module. As a result, these custom App Bridge web components are no longer correctly recognized by TypeScript when used with React 19.

This can lead to type errors when using components such as:

```
<ui-modal />
<ui-nav-menu />
<ui-save-bar />
<ui-title-bar />
```

Solution

Replace the global JSX declaration with React module augmentation:

```
declare module 'react' {
  namespace JSX {
    interface IntrinsicElements {
      'ui-modal': ...
    }
  }
}
```

The existing ref typing is preserved using import('react').LegacyRef, avoiding unnecessary direct type imports.

The change has been applied consistently to:

Modal
NavMenu
SaveBar
TitleBar
Compatibility

The implementation remains compatible with React 18 while enabling the expected JSX type resolution for React 19.

The existing App Bridge web component attributes and ref types are preserved.

Verification

The following checks pass successfully:

pnpm run type-check ✅
pnpm run lint ✅
pnpm run test ✅
git diff --check ✅
Manual JSX type verification with React 18 types ✅

No runtime behavior is changed by this PR; this is a TypeScript/JSX type compatibility fix.

Changeset

Added a patch changeset for @shopify/app-bridge-react.