### PR TITLE
Add React type compatibility tests

### DIFF
--- a/packages/app-bridge-react/package.json
+++ b/packages/app-bridge-react/package.json
@@ -24,7 +24,8 @@
     "build": "vite build",
     "watch": "vite build --watch --mode=development",
     "test": "vitest run --passWithNoTests",
-    "type-check": "tsc -p tsconfig.json --noEmit",
+    "type-check": "tsc -p tsconfig.json --noEmit && pnpm run type-check:tests",
+    "type-check:tests": "tsc -p tests && tsc -p tests/tsconfig.react19.json",
     "coverage": "vitest run --passWithNoTests --coverage",
     "lint": "oxlint -c .eslintrc.json"
   },
@@ -71,6 +72,7 @@
     "@shopify/typescript-configs": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "@types/react-19": "npm:@types/react@19.2.18",
     "@types/react-dom": "catalog:",
     "oxlint": "catalog:",
     "react": "catalog:",

--- a/packages/app-bridge-react/tests/tsconfig.json
+++ b/packages/app-bridge-react/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "include": ["types.test-d.tsx"]
+}

--- a/packages/app-bridge-react/tests/tsconfig.react19.json
+++ b/packages/app-bridge-react/tests/tsconfig.react19.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "react": ["node_modules/@types/react-19"],
+      "react/*": ["node_modules/@types/react-19/*"]
+    },
+    "types": []
+  }
+}

--- a/packages/app-bridge-react/tests/types.test-d.tsx
+++ b/packages/app-bridge-react/tests/types.test-d.tsx
@@ -1,0 +1,40 @@
+import {createRef} from 'react';
+import type {} from '@shopify/app-bridge-react';
+
+export const elements = (
+  <>
+    <ui-modal
+      id="product-modal"
+      variant="large"
+      src="/products"
+      ref={createRef<UIModalElement>()}
+    />
+    <ui-nav-menu ref={createRef<UINavMenuElement>()} />
+    <ui-save-bar
+      id="product-save-bar"
+      discardConfirmation
+      ref={createRef<UISaveBarElement>()}
+    />
+    <ui-title-bar title="Products" ref={createRef<UITitleBarElement>()} />
+  </>
+);
+
+// @ts-expect-error Unknown attributes should not be accepted.
+export const modalWithUnknownAttribute = <ui-modal unknownAttribute />;
+// @ts-expect-error Unknown attributes should not be accepted.
+export const navMenuWithUnknownAttribute = <ui-nav-menu unknownAttribute />;
+// @ts-expect-error Unknown attributes should not be accepted.
+export const saveBarWithUnknownAttribute = <ui-save-bar unknownAttribute />;
+// @ts-expect-error Unknown attributes should not be accepted.
+export const titleBarWithUnknownAttribute = <ui-title-bar unknownAttribute />;
+
+const wrongRef = createRef<{notAnAppBridgeElement: true}>();
+
+// @ts-expect-error The ref should point to a UIModalElement.
+export const modalWithWrongRef = <ui-modal ref={wrongRef} />;
+// @ts-expect-error The ref should point to a UINavMenuElement.
+export const navMenuWithWrongRef = <ui-nav-menu ref={wrongRef} />;
+// @ts-expect-error The ref should point to a UISaveBarElement.
+export const saveBarWithWrongRef = <ui-save-bar ref={wrongRef} />;
+// @ts-expect-error The ref should point to a UITitleBarElement.
+export const titleBarWithWrongRef = <ui-title-bar ref={wrongRef} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.28
+      '@types/react-19':
+        specifier: npm:@types/react@19.2.18
+        version: '@types/react@19.2.18'
       '@types/react-dom':
         specifier: 'catalog:'
         version: 18.3.7(@types/react@18.3.28)
@@ -1455,6 +1458,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@typescript-eslint/eslint-plugin@8.56.0':
     resolution: {integrity: sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==}
@@ -5007,6 +5013,10 @@ snapshots:
   '@types/react@18.3.28':
     dependencies:
       '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@types/react@19.2.18':
+    dependencies:
       csstype: 3.2.3
 
   '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':


### PR DESCRIPTION
## Summary

- add compile-time JSX tests for the App Bridge React custom elements
- run the same contract tests with React 18 and pinned React 19 types
- cover representative attributes, element-specific refs, unknown attributes, and invalid refs
- verify the React 19 compatibility fix from #579 through the package's generated public declarations

## Testing

- `pnpm build`
- `pnpm type-check`
- `pnpm test`
- `pnpm format:check`
